### PR TITLE
Fix playlist ignore errors crash

### DIFF
--- a/ytmdl/main.py
+++ b/ytmdl/main.py
@@ -298,7 +298,18 @@ def main(args):
         return
 
     # Try to extract the chapters
-    chapters = yt.get_chapters(link, args.ytdl_config)
+    try:
+        chapters = yt.get_chapters(link, args.ytdl_config)
+    except ExtractError:
+        if args.ignore_errors:
+            logger.info("--ignore-errors passed. Skipping this song!")
+            return
+
+        logger.critical(
+            "Wasn't able to extract chapter data.",
+            "Use `--ignore-errors` to ignore this error"
+        )
+        return
 
     # Add the current passed song as the only entry here
     # This dictionary will be cleared if the song is found to be containing


### PR DESCRIPTION
## Summary
- handle yt-dlp `None` return when `ignore-errors` is enabled
- propagate chapter extraction failure as ExtractError and handle it in `main`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688302db5f088331b3b00df98cce22f1